### PR TITLE
Make pytest.approx conversion compatible with < Py3.8

### DIFF
--- a/pytestify/fixes/asserts.py
+++ b/pytestify/fixes/asserts.py
@@ -136,7 +136,11 @@ class Visitor(NodeVisitor):
             if keyword.arg == 'places':
                 # assertAlmostEqual / assertAlmostEquals
                 const = keyword.value
-                kwargs['places'] = getattr(const, 'value', None)
+                try:
+                    kwargs['places'] = const.value
+                except AttributeError:
+                    # Prior to Python 3.8, const is actually a ast.Num object
+                    kwargs['places'] = const.n
         end_line = close_paren.line
         self.calls.append(
             Call(method, line - 1, call_idx, end_line - 1, **kwargs),


### PR DESCRIPTION
In Python3.8+, const.value is an ast.Const instance, which always has the `value` attribute defined

In earlier versions of Python, const.value is an ast.Num instance (in the particular case of the `places` keyword arg).

I don't see a clear way to do this without the ugliness of a try, except!  But it does make the tests pass in Python 3.6.5