### PR TITLE
Rewrite `==` to `is` if that's reasonably what we're testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [Unreleased]
 
+- Feature: Rewrites `self.assertEqual(a, None)` to `assert a is None` rather than `assert a == None`
 
 ## [1.0.8] - September 19th 2021
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ self.assertAlmostEqual(a, b)
 self.assertAlmostEqual(a, b, places=2)
 #   assert a == pytest.approx(b, abs=0.01)
 
+
+# improves the assert if reasonable
+self.assertEqual(a, None)   # assert a is None
+self.assertEqual(a, True)   # assert a is True
+
+
 # error messages
 self.assertTrue(a, msg='oh no!')  # assert a, 'oh no!'
 ```

--- a/pytestify/fixes/asserts.py
+++ b/pytestify/fixes/asserts.py
@@ -303,7 +303,10 @@ def rewrite_asserts(contents: str) -> str:
         # for equality comparators, turn the next comma into ' ==', etc
         if assert_type.type == 'binary':
             operator = assert_type.op
-            if should_swap_eq_for_is(call, tokens, comma):
+            if (
+                operator == ' ==' and
+                should_swap_eq_for_is(call, tokens, comma)
+            ):
                 operator = ' is'
 
             strip = assert_type.strip

--- a/tests/fixes/test_asserts.py
+++ b/tests/fixes/test_asserts.py
@@ -45,6 +45,14 @@ def test_rewrite_simple_asserts(before, after):
     'before, after', [
         ('self.assertEqual([a, b, c], d)', 'assert [a, b, c] == d'),
         ('self.assertEqual(len(a), len(b))', 'assert len(a) == len(b)'),
+        ('self.assertEqual(1, None)', 'assert 1 is None'),
+        ('self.assertEqual(a, True)', 'assert a is True'),
+        ('self.assertEqual(a, False)', 'assert a is False'),
+        (
+            'self.assertEqual(a, [True, False, None])',
+            'assert a == [True, False, None]',
+        ),
+        ('self.assertEqual(a, "True")', 'assert a == "True"'),
         (
             'self.assertEqual(min(1, 2, 3), min(1, 2, 3))',
             'assert min(1, 2, 3) == min(1, 2, 3)',


### PR DESCRIPTION
For example,

```python
self.assertEqual(a, True)
```

should be

```python
assert a is True
```