### PR TITLE
Add PyPI and conda-forge badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 pytestify
 =========
 
+[![alt](http://img.shields.io/pypi/v/pytestify.svg)](https://pypi.python.org/pypi/pytestify)
+[![alt](https://img.shields.io/conda/vn/conda-forge/pytestify.svg)](https://anaconda.org/conda-forge/pytestify)
+
 A tool to automatically change unittest to pytest. Similar to
 [unittest2pytest](https://github.com/pytest-dev/unittest2pytest),
 but with a few more features and written using AST and tokenize, rather


### PR DESCRIPTION
I added `pytestfify` to [`conda-forge`](https://github.com/conda-forge/pytestify-feedstock), and when I do that I usually go to the original repository and add a badge for the conda version, as this indicates to users that the package is also available there.

However I noticed you don't have any badges at all here, which can be just because you didn't think of adding them, or you might not like them at all.

So feel free to just close this PR in case you are not interested in having badges on the README, as I decided to go ahead with the PR to at least know `pytestify` is also on conda-forge. 👍

Thanks for writing the package!