### PR TITLE
Disable countEqual rewrite by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [1.4.0] - March 15th 2022
 
-- Rewrite count equal by default, rename from `--with-count-equal` to `--keep-count-equal`
-- Fixes #27: Suffixes were being added after the `msg=` parameter which was causing breaks
+- _This release has been yanked, since it was buggy._
 
 ## [1.3.2] - December 29th 2021
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or
 **Optional arguments**
 
 - [--keep-method-casing](#camelCase-to-snake_case)
-- [--keep-count-equal](#assertCountEqual)
+- [--with-count-equal](#assertCountEqual)
 
 Please read over all changes that pytestify makes. It's a new
 package, so there are bound to be issues.
@@ -128,7 +128,7 @@ def testHTTPThing(self):  # def test_httpthing(self):
 
 ### assertCountEqual
 
-Disable this behavior with `pytest path/to/file --keep-count-equal`.
+The `assertCountEqual` rewrite is risky, so opt-in with `pytest path/to/file --with-count-equal`.
 
 ```python
 self.assertItemsEqual(a, b)  # assert sorted(a) == sorted(b)

--- a/pytestify/_main.py
+++ b/pytestify/_main.py
@@ -44,7 +44,7 @@ def _fix_path(
         contents = remove_base_class(orig_contents)
         contents = rewrite_asserts(
             contents,
-            keep_count_equal=args.keep_count_equal,
+            with_count_equal=args.with_count_equal,
         )
 
         is_unittest_file = _no_ws(contents) != _no_ws(orig_contents)
@@ -82,7 +82,7 @@ def _fix_path(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filepaths', nargs='*')
-    parser.add_argument('--keep-count-equal', action='store_true')
+    parser.add_argument('--with-count-equal', action='store_true')
     parser.add_argument('--show-traceback', action='store_true')
     parser.add_argument('--keep-method-casing', action='store_true')
     args = parser.parse_args(argv)

--- a/pytestify/fixes/asserts.py
+++ b/pytestify/fixes/asserts.py
@@ -346,14 +346,14 @@ def remove_trailing_comma(call: Call, contents: list[str]) -> None:
         contents[last] = contents[last][:-1]
 
 
-def rewrite_asserts(contents: str, *, keep_count_equal: bool = False) -> str:
+def rewrite_asserts(contents: str, *, with_count_equal: bool = False) -> str:
     tokens = src_to_tokens(contents)
     visitor = Visitor(tokens).visit_text(contents)
     content_list = contents.splitlines()
 
     line_offset = 0
     for call in visitor.calls:
-        if keep_count_equal and call.name in (
+        if not with_count_equal and call.name in (
             'assertCountEqual', 'assertItemsEqual',
         ):
             continue

--- a/tests/fixes/test_asserts.py
+++ b/tests/fixes/test_asserts.py
@@ -280,16 +280,16 @@ def test_remove_msg_param(before, after):
 
 
 @pytest.mark.parametrize(
-    'before, keep_count_equal, after', [
+    'before, with_count_equal, after', [
         # opted-out
-        ('self.assertItemsEqual(a, b)', True, 'self.assertItemsEqual(a, b)'),
-        ('self.assertCountEqual(a, b)', True, 'self.assertCountEqual(a, b)'),
+        ('self.assertItemsEqual(a, b)', False, 'self.assertItemsEqual(a, b)'),
+        ('self.assertCountEqual(a, b)', False, 'self.assertCountEqual(a, b)'),
         (
             'self.assertItemsEqual(\n'
             '    a,\n'
             '    b\n'
             ')',
-            True,
+            False,
             'self.assertItemsEqual(\n'
             '    a,\n'
             '    b\n'
@@ -300,7 +300,7 @@ def test_remove_msg_param(before, after):
             '    a,\n'
             '    b\n'
             ')',
-            True,
+            False,
             'self.assertCountEqual(\n'
             '    a,\n'
             '    b\n'
@@ -312,7 +312,7 @@ def test_remove_msg_param(before, after):
             '    b,\n'
             '    "some error message"\n'
             ')',
-            True,
+            False,
             'self.assertCountEqual(\n'
             '    a,\n'
             '    b,\n'
@@ -323,16 +323,16 @@ def test_remove_msg_param(before, after):
         # opted-in
         (
             'self.assertItemsEqual(a, b)',
-            False,
+            True,
             'assert sorted(a) == sorted(b)',
         ),
         (
             'self.assertCountEqual(a, b)',
-            False,
+            True,
             'assert sorted(a) == sorted(b)',
         ),
         (
-            'self.assertCountEqual(a, b, "error")', False,
+            'self.assertCountEqual(a, b, "error")', True,
             'assert sorted(a) == sorted(b), "error"',
         ),
 
@@ -342,7 +342,7 @@ def test_remove_msg_param(before, after):
             '    a,\n'
             '    b\n'
             ')',
-            False,
+            True,
             'assert sorted(\n'
             '    a) == sorted(\n'
             '    b)',
@@ -352,7 +352,7 @@ def test_remove_msg_param(before, after):
             '    a,\n'
             '    b\n'
             ')',
-            False,
+            True,
             'assert sorted(\n'
             '    a) == sorted(\n'
             '    b)',
@@ -363,7 +363,7 @@ def test_remove_msg_param(before, after):
             '    b,\n'
             '    msg="Error"\n'
             ')',
-            False,
+            True,
             'assert sorted(\n'
             '    a) == sorted(\n'
             '    b), \\\n'
@@ -371,8 +371,8 @@ def test_remove_msg_param(before, after):
         ),
     ],
 )
-def test_opt_in_rewrites(before, keep_count_equal, after):
-    assert rewrite_asserts(before, keep_count_equal=keep_count_equal) == after
+def test_opt_in_rewrites(before, with_count_equal, after):
+    assert rewrite_asserts(before, with_count_equal=with_count_equal) == after
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,16 +54,16 @@ def camelCaseButNotTest():
 
 
 class TestCliArgs:
-    def test_keep_count_equal(self, f):
+    def test_rewrites_count_equal(self, f):
         f.write_text('self.assertCountEqual(a, b)\n')
-        ret = main([str(f), '--keep-count-equal'])
-
-        assert f.read_text() == 'self.assertCountEqual(a, b)\n'
-        assert ret == 0
-
-    def test_dont_keep_count_equal(self, f):
-        f.write_text('self.assertCountEqual(a, b)\n')
-        ret = main([str(f)])
+        ret = main([str(f), '--with-count-equal'])
 
         assert f.read_text() == 'assert sorted(a) == sorted(b)\n'
         assert ret == 1
+
+    def test_doesnt_rewrite_count_equal(self, f):
+        f.write_text('self.assertCountEqual(a, b)\n')
+        ret = main([str(f)])
+
+        assert f.read_text() == 'self.assertCountEqual(a, b)\n'
+        assert ret == 0


### PR DESCRIPTION
This was buggy, woops!

I'll try re-enabling when I rewrite it from handling text to handling tokens, like pyupgrade does